### PR TITLE
Update selector naming to work with CSS updates

### DIFF
--- a/app/views/spree/components/product_selection/_option_type.html.erb
+++ b/app/views/spree/components/product_selection/_option_type.html.erb
@@ -18,7 +18,7 @@
             "data-presentation": option_value.presentation,
             "data-option-index": index
           ) %>
-          <span class='<%= "selected-#{option_type.presentation.downcase}" %> <%= "selected-#{option_value.name.downcase}" %>'>
+          <span class='<%= "selection-#{option_type.presentation.downcase}" %> <%= "selected-#{option_value.name.downcase}" %>'>
             <span class="value"><%= option_value.presentation %></span>
           </span>
         </label>

--- a/spec/features/product_swatches_spec.rb
+++ b/spec/features/product_swatches_spec.rb
@@ -12,52 +12,53 @@ RSpec.describe 'product swatches', :js, type: :feature do
   it 'shows the product options in the show page' do
     expect(page).to have_css('.optionTypeSize')
     within('.optionTypeSize') do
-      selectors = find_all('.selection-items', visible: true).count
+      selectors = find_all('.selection-size', visible: true).count
       expect(selectors).to eq(4)
     end
 
     expect(page).to have_css('.optionTypeColor')
     within('.optionTypeColor') do
-      selectors = find_all('.selection-items', visible: true).count
+      selectors = find_all('.selection-color', visible: true).count
       expect(selectors).to eq(3)
     end
   end
 
   describe 'when selecting another option' do
-    it 'updates the selected option type text' do
-      selectors = all('.selection-items')
+    it 'updates the selection option type text' do
+      selectors_sizes = all('.selection-size')
+      selectors_colors = all('.selection-color')
       expect(find('#selected-size').text).to eq('S')
       expect(find('#selected-color').text).to eq('Blue')
 
-      selectors[1].click
+      selectors_sizes[1].click
       expect(find('#selected-size').text).to eq('M')
 
-      selectors[2].click
-      selectors[5].click
+      selectors_sizes[2].click
+      selectors_colors[2].click
       expect(find('#selected-size').text).to eq('L')
       expect(find('#selected-color').text).to eq('White')
     end
 
     it 'hides option types that do not have a match' do
       within('.optionTypeSize') do
-        @option_type_size = find_all('.selection-items', visible: true)
+        @option_type_size = find_all('.selection-size', visible: true)
       end
 
       within('.optionTypeColor') do
         @option_type_size[1].click
-        color_selectors = find_all('.selection-items', visible: true).count
+        color_selectors = find_all('.selection-color', visible: true).count
         expect(color_selectors).to eq(1)
 
         @option_type_size[2].click
-        color_selectors = find_all('.selection-items', visible: true).count
+        color_selectors = find_all('.selection-color', visible: true).count
         expect(color_selectors).to eq(2)
 
         @option_type_size[3].click
-        color_selectors = find_all('.selection-items', visible: true).count
+        color_selectors = find_all('.selection-color', visible: true).count
         expect(color_selectors).to eq(1)
 
         @option_type_size[0].click
-        color_selectors = find_all('.selection-items', visible: true).count
+        color_selectors = find_all('.selection-color', visible: true).count
         expect(color_selectors).to eq(3)
       end
     end
@@ -65,17 +66,15 @@ RSpec.describe 'product swatches', :js, type: :feature do
     it 'updates the price if variant price is different than original' do
       expect(find('#product-price').text).to eq('$19.99')
 
-      all('.selection-items')[3].click
+      all('.selection-size')[3].click
       expect(find('#product-price').text).to eq('$10.00')
     end
   end
 
   describe 'when an Item is added to the cart' do
-    it 'adds the correct swatch selected variant to my cart' do
-      selectors = all('.selection-items')
-      selectors[2].click
-      selectors[5].click
-
+    it 'adds the correct swatch selection variant to my cart' do
+      all('.selection-size')[2].click
+      all('.selection-color')[1].click
       find('#add-to-cart-button').click
       expect(find('.item-info__options').text).to have_content('Size: L, Color: White')
     end


### PR DESCRIPTION
The original radio selectors were hidden to add custom radio selectors.
This failed multiple tests due to hidden element selectors. Changed
selector names to the updated custom radio selector names so the tests
can find the correct elements. Updated "selected" to "selection" to be
more explicit with the elements purpose.